### PR TITLE
a Rust program to find the adjoint of a matrix

### DIFF
--- a/program/program/find-the-adjoint-of-a-matrix/find_the_adjoint_of_a_matrix.rs
+++ b/program/program/find-the-adjoint-of-a-matrix/find_the_adjoint_of_a_matrix.rs
@@ -1,0 +1,69 @@
+fn main() {
+    // Define the input matrix
+    let matrix: [[i32; 3]; 3] = [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+    ];
+
+    // Calculate and print the adjoint of the matrix
+    let adjoint_matrix = adjoint(&matrix);
+    print_adjoint_matrix(&adjoint_matrix);
+}
+
+fn adjoint(matrix: &[[i32; 3]; 3]) -> [[i32; 3]; 3] {
+    let mut adjoint_matrix: [[i32; 3]; 3] = [[0; 3]; 3];
+
+    for i in 0..3 {
+        for j in 0..3 {
+            // Calculate the cofactor for each element
+            let cofactor_value = cofactor(matrix, i, j);
+
+            // Transpose the cofactor matrix to get the adjoint matrix
+            adjoint_matrix[j][i] = cofactor_value;
+        }
+    }
+
+    adjoint_matrix
+}
+
+fn cofactor(matrix: &[[i32; 3]; 3], row: usize, col: usize) -> i32 {
+    // Calculate the minor matrix by excluding the current row and column
+    let mut minor_matrix: [[i32; 2]; 2] = [[0; 2]; 2];
+    let mut minor_row = 0;
+    for i in 0..3 {
+        if i == row {
+            continue;
+        }
+        let mut minor_col = 0;
+        for j in 0..3 {
+            if j == col {
+                continue;
+            }
+            minor_matrix[minor_row][minor_col] = matrix[i][j];
+            minor_col += 1;
+        }
+        minor_row += 1;
+    }
+
+    // Calculate the determinant of the minor matrix
+    let minor_det = (minor_matrix[0][0] * minor_matrix[1][1]) - (minor_matrix[0][1] * minor_matrix[1][0]);
+
+    // Apply the sign based on the position of the element in the matrix
+    let sign = if (row + col) % 2 == 0 { 1 } else { -1 };
+
+    // Multiply the determinant by the sign to get the cofactor
+    sign * minor_det
+}
+
+fn print_adjoint_matrix(matrix: &[[i32; 3]; 3]) {
+    print!("[");
+    for row in matrix.iter().take(matrix.len() - 1) {
+        print!("{}, ", format_row(row));
+    }
+    print!("{}]", format_row(matrix.last().unwrap()));
+}
+
+fn format_row(row: &[i32; 3]) -> String {
+    format!("[{}]", row.iter().map(|&x| x.to_string()).collect::<Vec<_>>().join(", "))
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description

a Rust program to find the adjoint of a matrix

The adjoint of a square matrix A is the transpose of the matrix of cofactors of A. The adjoint of a matrix A is denoted as A*.

## 🐞 Related Issue

<!-- If this pull request closes an issue, please mention the issue number below 👇🏻 -->
<!-- For example, use Issue Number like => Closes #404 -->
<!-- Or, use Issue Url like => Closes https://github.com/OWNER/REPO/issues/404 -->

Closes #3010

## 📋 Explanation of changes

- `Matrix Calculation`: The Rust program calculates the adjoint of a 3x3 matrix using the formula based on the transpose of cofactors.
- `Cofactor Calculation`: The cofactor function computes the cofactor of each matrix element by determining the minor matrix and applying the appropriate sign.
- `Output Formatting`: The program prints the resulting adjoint matrix in a single-line format, with each row enclosed in square brackets and separated by commas.

<!-- GitHub Copilot: https://githubnext.com/projects/copilot-for-pull-requests -->
