### PR TITLE
Create ConvertStringToPascalcase.swift

### DIFF
--- a/program/program/convert-string-to-pascalcase/ConvertStringToPascalcase.swift
+++ b/program/program/convert-string-to-pascalcase/ConvertStringToPascalcase.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+func convertToPascalCase(_ input: String) -> String {
+    // Split the string into words separated by spaces or punctuation using a character set
+    let words = input.components(separatedBy: CharacterSet.alphanumerics.inverted).filter { !$0.isEmpty }
+    
+    // Capitalize the first letter of each word and concatenate them
+    let pascalCase = words.map { $0.capitalized }.joined()
+    
+    return pascalCase
+}
+
+// Taking input from the user
+print("Please enter a string to convert to PascalCase:")
+if let input = readLine() {
+    let pascalCaseOutput = convertToPascalCase(input)
+    print("PascalCase Output: \(pascalCaseOutput)")
+} else {
+    print("Failed to read input.")
+}


### PR DESCRIPTION
## 📑 Description

This pull request introduces a Swift program that converts any given string into PascalCase format. PascalCase is a common naming convention in programming and documentation where the first letter of each word is capitalized without spaces between them. This implementation handles various input cases, including strings with spaces, punctuation, and mixed case letters.

The function provided `convertToPascalCase` accepts a string input and returns a new string where each word's initial is capitalized and all words are concatenated without any spaces, adhering to the PascalCase style.

## 🐞 Related Issue

Closes #3054

## 📦 Changes Made

- Added a new Swift file `StringToPascalCase.swift`.
- Implemented the `convertToPascalCase` function that processes the input string to output it in PascalCase.
- The function uses `CharacterSet` to split the string by non-alphanumeric characters, filters out any empty substrings, capitalizes each valid substring, and then joins them into a single string.
