### PR TITLE
Create convert_string_to_consonantcase.hs

### DIFF
--- a/program/program/convert-string-to-consonantcase/convert_string_to_consonantcase.hs
+++ b/program/program/convert-string-to-consonantcase/convert_string_to_consonantcase.hs
@@ -1,0 +1,13 @@
+import Data.Char (toLower, toUpper)
+
+consonantCase :: String -> String
+consonantCase [] = []
+consonantCase (x:xs)
+    | elem x "aeiouAEIOU" = toLower x : consonantCase xs
+    | otherwise = toUpper x : consonantCase xs
+
+main :: IO ()
+main = do
+    putStrLn "Enter a string:"
+    input <- getLine
+    putStrLn $ "Consonant-case: " ++ consonantCase input


### PR DESCRIPTION
📑 Description
This PR introduces a Haskell function to convert a given string to consonant-case. In consonant-case, all consonants are transformed into uppercase letters, and all vowels are converted into lowercase letters.

🐞 Related Issue
Closes #3806

📦 Changes Made
Added a new Haskell file convert_string_to_consonantcase.hss.
Implemented the function consonantCase to convert a string to consonant-case.
The function takes a string as input and applies the transformation based on the vowel-consonant classification.
Utilized Haskell's pattern matching and list comprehension to efficiently perform the conversion.